### PR TITLE
t.rast.mosaic.py: Correct cloud masking

### DIFF
--- a/t.rast.mosaic.py
+++ b/t.rast.mosaic.py
@@ -253,8 +253,8 @@ def main():
                 noclouds = "%s_noclouds" % scene['raster']
             scenes[scene_key]['noclouds'] = noclouds
             rm_rasters.append(noclouds)
-            expression = ("%s = if( isnull(%s) ||| %s == 0, %s, null() )"
-                          % (noclouds, scene['clouds'], scene['clouds'],
+            expression = ("%s = if( isnull(%s), %s, null() )"
+                          % (noclouds, scene['clouds'],
                           scene['raster']))
 
             # grass.run_command('r.mapcalc', expression=expression, quiet=True)


### PR DESCRIPTION
Cloud rasters created by **t.sentinel.mask** now have the value 0 for clouds, and **null()** for everything else. **t.rast.mosaic** expected any value except null() **OR** 0 in order to remove clouds from the resulting raster if no alternative non-cloud pixels can be found. 
This is fixed 