### PR TITLE
Do not fail if number of input rasters and number of input cloud/shadow rasters are not identical

### DIFF
--- a/t.rast.mosaic.py
+++ b/t.rast.mosaic.py
@@ -213,12 +213,12 @@ def main():
         cloudrasters = [x.split('|')[0] for x in grass.parse_command('t.rast.list', input=clouds, flags='u')]
         cloudtimes = [x.split('|')[2] for x in grass.parse_command('t.rast.list', input=clouds, flags='u')]
         if len(strdsrasters) != len(cloudrasters):
-            grass.fatal(_("Number of raster in <input> strds and <clouds> strds are not the same."))
+            grass.warning(_("Number of raster in <input> strds and <clouds> strds are not the same."))
     if shadows:
         shadowrasters = [x.split('|')[0] for x in grass.parse_command('t.rast.list', input=shadows, flags='u')]
         shadowtimes = [x.split('|')[2] for x in grass.parse_command('t.rast.list', input=shadows, flags='u')]
         if len(strdsrasters) != len(shadowrasters):
-            grass.fatal(_("Number of raster in <input> strds and <shadows> strds are not the same."))
+            grass.warning(_("Number of raster in <input> strds and <shadows> strds are not the same."))
 
     scenes = dict()
     for strdsrast, strdstime in zip(strdsrasters, strdstimes):


### PR DESCRIPTION
In https://github.com/mundialis/t.sentinel/pull/3, cloud/shadow rasters from the same date but different input scenes (e.g. due to different S2-UTM-tiles) are merged together to a single raster, reducing the total number of clouds/shadow rasters in the resulting spacetime raster dataset. Because of this, `t.rast.mosaic` should allow having different amount of input rasters and cloud/shadow rasters.